### PR TITLE
Edit Icon Toggle[2/2]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1057,6 +1057,9 @@
     <string name="qs_running_services_title">Running Services Icon</string>
     <string name="qs_running_services_summary">Disable the tile running services icon in the footer</string>
 
+    <string name="qs_edit_title">Edit Icon</string>
+    <string name="qs_edit_summary">Disable the tile edit icon in the footer</string>
+
     <!-- Wallpaper tint -->
     <string name="wallpaper_tint_power_menu">Power menu background tint</string>
     <string name="wallpaper_tint_recents">Recents background tint</string>

--- a/res/xml/quick_settings.xml
+++ b/res/xml/quick_settings.xml
@@ -78,6 +78,12 @@
         android:defaultValue="false"/>
 
         <org.aospextended.extensions.preference.SystemSettingSwitchPreference
+            android:key="qs_edit_toggle"
+            android:title="@string/qs_edit_title"
+            android:summary="@string/qs_edit_summary"
+            android:defaultValue="false" />
+
+        <org.aospextended.extensions.preference.SystemSettingSwitchPreference
             android:key="qs_running_services_toggle"
             android:title="@string/qs_running_services_title"
             android:summary="@string/qs_running_services_summary"


### PR DESCRIPTION
aex edits(@hamza-badar):- Adapt for oreo

Adds toggle for quick tiles edit

@nathanchance edit: Settings are all disabled by default, enabling them disables the option

Signed-off-by: Joe Maples <joe@frap129.org>
Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>